### PR TITLE
add E14C2IMS (P14_A10RB, P14_A10SC, P14_A10RAS)

### DIFF
--- a/etc/isw.conf
+++ b/etc/isw.conf
@@ -895,7 +895,7 @@ gpu_fan_speed_5 = 85
 gpu_fan_speed_6 = 100
 
 [E14C2IMS]
-# P14_A10RC P14_A10SC P14_A10RAS
+# P14_A10RB P14_A10SC P14_A10RAS
 # E14C2IMS.102
 address_profile = MSI_ADDRESS_DEFAULT
 fan_mode = 140

--- a/etc/isw.conf
+++ b/etc/isw.conf
@@ -894,6 +894,41 @@ gpu_fan_speed_4 = 80
 gpu_fan_speed_5 = 85
 gpu_fan_speed_6 = 100
 
+[E14C2IMS]
+# P14_A10RC P14_A10SC P14_A10RAS
+# E14C2IMS.102
+address_profile = MSI_ADDRESS_DEFAULT
+fan_mode = 140
+battery_charging_threshold = 100
+# CPU
+cpu_temp_0 = 56
+cpu_temp_1 = 62
+cpu_temp_2 = 68
+cpu_temp_3 = 74
+cpu_temp_4 = 80
+cpu_temp_5 = 90
+cpu_fan_speed_0 = 0
+cpu_fan_speed_1 = 50
+cpu_fan_speed_2 = 65
+cpu_fan_speed_3 = 73
+cpu_fan_speed_4 = 80
+cpu_fan_speed_5 = 90
+cpu_fan_speed_6 = 100
+# GPU
+gpu_temp_0 = 53
+gpu_temp_1 = 58
+gpu_temp_2 = 63
+gpu_temp_3 = 68
+gpu_temp_4 = 80
+gpu_temp_5 = 90
+gpu_fan_speed_0 = 0
+gpu_fan_speed_1 = 60
+gpu_fan_speed_2 = 70
+gpu_fan_speed_3 = 80
+gpu_fan_speed_4 = 90
+gpu_fan_speed_5 = 100
+gpu_fan_speed_6 = 105
+
 [16U4EMS1]
 # GL65_9SCK (using 1st/cpu & 2nd/gpu profile in 16U4EMS1.102.zip)
 # 16U4EMS1.102


### PR DESCRIPTION
New configuration entry for the Prestige-14-A10X